### PR TITLE
Fixing a few small mistakes

### DIFF
--- a/blueprint/index.md
+++ b/blueprint/index.md
@@ -137,7 +137,7 @@ The following environment variables hold the OAuth credential grant that is used
 
 ### Clone the GitHub repository
 
-Clone the [survey-sms-delivery-blueprint](https://github.com/GenesysCloudBlueprints/architect-flow-public-api-blueprint "Opens the project repository on GitHub") repository to your local machine.
+Clone the [survey-sms-delivery-blueprint](https://github.com/GenesysCloudBlueprints/survey-sms-delivery-blueprint "Opens the project repository on GitHub") repository to your local machine.
 
 ### Configure the Terraform module
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     genesyscloud = {
-      source = "genesys.com/mypurecloud/genesyscloud"
-      version = "0.1.0"
+      source  = "mypurecloud/genesyscloud"
+      version = "1.51.0"
     }
   }
 }

--- a/terraform/modules/data-actions/main.tf
+++ b/terraform/modules/data-actions/main.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     genesyscloud = {
-      source = "genesys.com/mypurecloud/genesyscloud"
-      version = "0.1.0"
+      source  = "mypurecloud/genesyscloud"
+      version = "1.51.0"
     }
   }
 }

--- a/terraform/modules/flows/main.tf
+++ b/terraform/modules/flows/main.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     genesyscloud = {
-      source = "genesys.com/mypurecloud/genesyscloud"
-      version = "0.1.0"
+      source  = "mypurecloud/genesyscloud"
+      version = "1.51.0"
     }
   }
 }
@@ -22,7 +22,7 @@ resource "null_resource" "deploy_archy_flow" {
       module.data_actions,
     ]
     provisioner "local-exec" {
-        command = "  archy publish --forceUnlock --file SendSurvey_v1-0.yaml --clientId $GENESYSCLOUD_OAUTHCLIENT_ID --clientSecret $GENESYSCLOUD_OAUTHCLIENT_SECRET --location $GENESYSCLOUD_ARCHY_REGION  --overwriteResultsFile --resultsFile results.json "
+        command = "  archy publish --forceUnlock --file SendSurvey_v1-0.yaml --clientId $GENESYSCLOUD_OAUTHCLIENT_ID --clientSecret $GENESYSCLOUD_OAUTHCLIENT_SECRET --location $GENESYSCLOUD_ARCHY_LOCATION  --overwriteResultsFile --resultsFile results.json "
     }
 }
 

--- a/terraform/modules/media-retention-policies/main.tf
+++ b/terraform/modules/media-retention-policies/main.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     genesyscloud = {
-      source = "genesys.com/mypurecloud/genesyscloud"
-      version = "0.1.0"
+      source  = "mypurecloud/genesyscloud"
+      version = "1.51.0"
     }
   }
 }


### PR DESCRIPTION
* The link for cloning was pointing to the wrong repository 
* The readme says to set the env var `GENESYSCLOUD_ARCHY_LOCATION` , but the null_resource uses the env var `GENESYSCLOUD_ARCHY_REGION` for the `--location` flag , so I updated the command to use `GENESYSCLOUD_ARCHY_LOCATION` instead 
* The versions in the provider.tf files were pointing to "0.1.0" (the locally compiled provider) , so I changed it to the latest version 1.51.0. Andrew Appleton tested it out with the latest version and confirmed that it still works i.e. no changes since this blueprint was written have broken anything in this tf config 